### PR TITLE
Fix README variables to match defaults/main.yml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ activemq_install_root: /opt
 User\group to install as:
 ```
 activemq_user: ubuntu
-activemq_group: ubuntu
+```
+
+Whether to create user if not present:
+```
+activemq_create_user: yes
 ```
 
 ## Dependencies


### PR DESCRIPTION
**GitHub Issue**: none

Just going through trying to figure out stuff works together...

# What does this Pull Request do?

Updates the readme, which provides descriptions of the variables, to match the ones that are currently in defaults/main.yml.

My hypothesis is that defaults/main.yml is a magickal ansible naming scheme and its contents will be understood as variables that could be passed in when this role is called, but also gives their default values if this role is called with no values provided. 

And as far as I can tell, claw-playbook mentions this in requirements.yml and doesn't pass `activemq_version` or any other variable so the defaults _are_ what get used when the playbook runs.

# What's new?
Diff is straightforward... took out a variable that doesn't exist/get used; and made my best guess as to what `activemq_create_user` means.

# How should this be tested?

Does this match your mental model?

# Additional Notes:

Just getting warmed up.

# Interested parties

sup @Islandora-Devops/committers
