### PR TITLE
Don't use default password for ActiveMQ admin

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,16 @@
   args:
     creates: "{{ activemq_install_root }}/activemq"
 
+- name: Remove jetty-realm.properties
+  file:
+    path: "{{ activemq_install_root }}/activemq/conf/jetty-realm.properties"
+    state: absent
+
+- name: Set ActiveMQ admin password
+  template:
+    src: "jetty-realm.properties.j2"
+    dest: "{{ activemq_install_root }}/activemq/conf/jetty-realm.properties"
+
 # Transitional removal of old-style init.d symlink
 # This task can be removed in the future.
 - name: Remove init.d symlink

--- a/templates/jetty-realm.properties.j2
+++ b/templates/jetty-realm.properties.j2
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+## 
+## http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# Defines users that can access the web (console, demo, etc.)
+# username: password [,rolename ...]
+admin: {{ activemq_admin_password }}, admin 
+user: user, user


### PR DESCRIPTION
**GitHub Issue**: none

# What does this Pull Request do?

Set this up a for our staging and production setup at York, and figured I might as well share it upstream if y'all are interested.

Allows for the configuration of an ActiveMQ password:

- Add jetty-realm.properties template
- Set a variable for password


# How should this be tested?

- Add fork and branch to requirements
- Set a `activemq_admin_password` value in `inventory/vagrant/group_vars/all/passwords.yml`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
